### PR TITLE
Allow validation errors to be attached to HttpBadRequest

### DIFF
--- a/.changeset/twelve-swans-sleep.md
+++ b/.changeset/twelve-swans-sleep.md
@@ -1,0 +1,27 @@
+---
+'@httpx/exception': minor
+---
+
+Support ValidationError in HttpBadRequest
+
+In some circumstances you might find useful to append the validation errors to
+`HttpBadRequest`. Here's a quick example:
+
+```typescript
+const e400 = new HttpBadRequest({
+  errors: [
+      {
+          message: 'Invalid email',
+          path: 'email',
+          code: 'invalid_email',
+      },
+      {
+          message: 'Invalid address',
+          path: ['addresses', 0, 'line1'],
+          code: 'empty_string',
+      },
+  ]
+});
+console.log(e400.errors)
+```
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # @httpx/exception
 
-Delightful http exceptions. Crafted with node, browsers, ssr frameworks and error logging in mind.
+Plain http exceptions for node, deno, edge and browsers. No deps, lightweight, first class typescript
+experience. Offer a built-in serializer in case you'll need it in hybrid context (àlà nextjs) or for logging
+purposes.
 
 [![npm](https://img.shields.io/npm/v/@httpx/exception?style=for-the-badge&labelColor=222)](https://www.npmjs.com/package/@httpx/exception)
 [![size](https://img.shields.io/bundlephobia/minzip/@httpx/exception@latest?label=Max&style=for-the-badge&labelColor=333&color=informational)](https://bundlephobia.com/package/@httpx/exception@latest)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,6 @@
-Delightful http exceptions. Crafted with node, browsers, ssr frameworks and error logging in mind.
+Plain http exceptions for node, deno, edge and browsers. No deps, lightweight, first class typescript
+experience. Offer a built-in serializer in case you'll need it in hybrid context (àlà nextjs) or for logging
+purposes.
 
 [![npm](https://img.shields.io/npm/v/@httpx/exception?style=for-the-badge&labelColor=222)](https://www.npmjs.com/package/@httpx/exception)
 [![size](https://img.shields.io/bundlephobia/minzip/@httpx/exception@latest?label=Max&style=for-the-badge&labelColor=333&color=informational)](https://bundlephobia.com/package/@httpx/exception@latest)
@@ -84,16 +86,17 @@ throw new HttpInternalServerError({
 
 #### HttpException properties
 
-| HttpException | Type      | Description                                                                                                                        |
-| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| statusCode    | `number`  | Http error status code (400-599).                                                                                                  |
-| message       | `string`  | Default or provided message.                                                                                                       |
-| url           | `string?` | Origin url ([about context](#about-context)).                                                                                      |
-| method        | `string?` | Origin http method ([about context](#about-context)).                                                                              |
-| code          | `string?` | Custom code ([about context](#about-context)).                                                                                     |
-| errorId       | `string?` | Unique id ([about context](#about-context)).                                                                                       |
-| stack         | `string?` | @see [Error.prototype.stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) on MDN. |
-| cause         | `Error?`  | @see [about error cause](#about-errorcause)                                                                                        |
+| HttpException | Type                | Description                                                                                                                        |
+| ------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| statusCode    | `number`            | Http error status code (400-599).                                                                                                  |
+| message       | `string`            | Default or provided message.                                                                                                       |
+| url           | `string?`           | Origin url ([about context](#about-context)).                                                                                      |
+| method        | `string?`           | Origin http method ([about context](#about-context)).                                                                              |
+| code          | `string?`           | Custom code ([about context](#about-context)).                                                                                     |
+| errorId       | `string?`           | Unique id ([about context](#about-context)).                                                                                       |
+| stack         | `string?`           | @see [Error.prototype.stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) on MDN. |
+| cause         | `Error?`            | @see [about error cause](#about-errorcause)                                                                                        |
+| errors?       | `ValidationError[]` | Only supported by HttpBadRequest                                                                                                   |
 
 ### Factories
 
@@ -216,6 +219,29 @@ const deserialized = createFromSerializable(serializableObject);
 ```
 
 ## Advanced
+
+### Validation errors
+
+In some circumstances you might find useful to append the validation errors to
+`HttpBadRequest`. Here's a quick example:
+
+```typescript
+const e400 = new HttpBadRequest({
+  errors: [
+    {
+      message: "Invalid email",
+      path: "email",
+      code: "invalid_email",
+    },
+    {
+      message: "Invalid address",
+      path: ["addresses", 0, "line1"],
+      code: "empty_string",
+    },
+  ],
+});
+console.log(e400.errors);
+```
 
 ### Non-official status codes
 

--- a/packages/exception/README.md
+++ b/packages/exception/README.md
@@ -1,6 +1,8 @@
 # @httpx/exception
 
-Delightful http exceptions. Crafted with node, browsers, ssr frameworks and error logging in mind.
+Plain http exceptions for node, deno, edge and browsers. No deps, lightweight, first class typescript
+experience. Offer a built-in serializer in case you'll need it in hybrid context (àlà nextjs) or for logging
+purposes.
 
 [![npm](https://img.shields.io/npm/v/@httpx/exception?style=for-the-badge&labelColor=222)](https://www.npmjs.com/package/@httpx/exception)
 [![size](https://img.shields.io/bundlephobia/minzip/@httpx/exception@latest?label=Max&style=for-the-badge&labelColor=333&color=informational)](https://bundlephobia.com/package/@httpx/exception@latest)
@@ -14,11 +16,11 @@ Delightful http exceptions. Crafted with node, browsers, ssr frameworks and erro
 
 ## Highlights
 
-- 🚀&nbsp; Dead simple: [explicit named imports](https://belgattitude.github.io/httpx/#/?id=named-exceptions) and/or [status code](https://belgattitude.github.io/httpx/#/?id=factories).
-- 📡&nbsp; Works everywhere: node, browsers, edge... framework agnostic, no deps.
+- 🚀&nbsp; All HTTP error status through [explicit named imports](https://belgattitude.github.io/httpx/#/?id=named-exceptions) and/or [status code](https://belgattitude.github.io/httpx/#/?id=factories).
 - 🎥&nbsp; Logger friendly with [contextual](https://belgattitude.github.io/httpx/#/?id=about-context) info. Less guessing games.
 - 🐎&nbsp; [Serializable](https://belgattitude.github.io/httpx/#/?id=serializer) to cover Server-Side-Rendering use-cases (nextjs, superjson,...).
 - 🎯&nbsp; Up to standards. [extends](https://belgattitude.github.io/httpx/#/?id=uml-class-diagram) Error class with [stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) and [Error.cause](https://belgattitude.github.io/httpx/#/?id=about-errorcause) support.
+- 📡&nbsp; Works everywhere: node, browsers, edge... framework agnostic, no deps.
 - 🍃&nbsp; [Lightweight](https://bundlephobia.com/package/@httpx/exception@latest) - [treeshakable](https://github.com/belgattitude/httpx/blob/main/packages/exception/.size-limit.cjs) - wide [browser coverage](https://browserslist.dev/?q=PjAuMjUlLCBub3QgZGVhZA%3D%3D) (trade-off).
 - ✨‍&nbsp; Default statusText as [error message](https://belgattitude.github.io/httpx/#/?id=about-default-message). Less chars, divergence...
 - 🧙‍&nbsp; IDE friendly. Typescript - typedoc with links to mdn and description.

--- a/packages/exception/src/client/HttpBadRequest.ts
+++ b/packages/exception/src/client/HttpBadRequest.ts
@@ -1,5 +1,5 @@
 import { HttpClientException } from '../base';
-import type { HttpExceptionParams } from '../types';
+import type { HttpExceptionParams, ValidationError } from '../types';
 import { getSuper } from '../utils';
 
 /**
@@ -13,9 +13,18 @@ import { getSuper } from '../utils';
  */
 export class HttpBadRequest extends HttpClientException {
   static readonly STATUS = 400;
-  constructor(msgOrParams?: HttpExceptionParams | string) {
+  public readonly errors: ValidationError[];
+  constructor(
+    msgOrParams?:
+      | (HttpExceptionParams & { errors?: ValidationError[] })
+      | string
+  ) {
     const name = 'BadRequest';
     super(400, getSuper(name, msgOrParams));
+    this.errors =
+      typeof msgOrParams === 'object' && msgOrParams.errors
+        ? msgOrParams.errors
+        : [];
     Object.setPrototypeOf(this, HttpBadRequest.prototype);
     this.name = `Http${name}`;
   }

--- a/packages/exception/src/client/HttpPaymentRequired.ts
+++ b/packages/exception/src/client/HttpPaymentRequired.ts
@@ -11,7 +11,6 @@ import { getSuper } from '../utils';
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402
  * @see https://httpstatus.in/402/
  */
-
 export class HttpPaymentRequired extends HttpClientException {
   static readonly STATUS = 402;
   constructor(msgOrParams?: HttpExceptionParams | string) {

--- a/packages/exception/src/index.ts
+++ b/packages/exception/src/index.ts
@@ -2,6 +2,7 @@ export type {
   HttpExceptionParams,
   HttpStatusCode,
   HttpExceptionParamsWithStatus,
+  ValidationError,
 } from './types';
 export * from './base';
 export * from './client';

--- a/packages/exception/src/types/ValidationError.ts
+++ b/packages/exception/src/types/ValidationError.ts
@@ -1,0 +1,13 @@
+/**
+ * Related to HttpBadRequest, ValidationError contains additional validation info.
+ * Slightly inspired from https://jsonapi.org/format/1.2/#error-objects
+ * and zod (path).
+ */
+export type ValidationError = {
+  /** Param name or path, ie: 'email' or ['addresses', 0, 'line1'] */
+  path: string | (string | number)[];
+  /** A short, human-readable summary of the problem */
+  message: string;
+  /** An application-specific error code, expressed as a string value. */
+  code?: string;
+};

--- a/packages/exception/src/types/index.ts
+++ b/packages/exception/src/types/index.ts
@@ -3,3 +3,4 @@ export type { HttpExceptionParamsWithStatus } from './HttpExceptionParamsWithSta
 export type { HttpStatusCode } from './HttpStatusCode';
 export type { HttpMethod } from './HttpMethod';
 export type { AssignedStatusCodes } from './AssignedStatusCodes';
+export type { ValidationError } from './ValidationError';

--- a/packages/exception/test/specs/bad-request-with-errors.test.ts
+++ b/packages/exception/test/specs/bad-request-with-errors.test.ts
@@ -1,0 +1,23 @@
+import type { ValidationError } from '../../src';
+import { HttpBadRequest } from '../../src/client';
+
+describe('HttpBadRequest with extra errors', () => {
+  const errors: ValidationError[] = [
+    {
+      message: 'Invalid email',
+      path: 'email',
+      code: 'invalid_email',
+    },
+    {
+      message: 'Invalid address',
+      path: ['addresses', 0, 'line1'],
+      code: 'empty_string',
+    },
+  ];
+  it('should return unmodified errors', () => {
+    const e400 = new HttpBadRequest({
+      errors,
+    });
+    expect(e400.errors).toStrictEqual(errors);
+  });
+});

--- a/packages/exception/test/specs/error-cause-support.test.ts
+++ b/packages/exception/test/specs/error-cause-support.test.ts
@@ -19,12 +19,12 @@ describe(`when Error.cause isn't supported`, () => {
 
   const scenarios: [name: string, cls: HttpException][] = [
     ['HttpException', new HttpException(500, params)],
-    ['HttpClientExeption', new HttpClientException(404, params)],
-    ['HttpServerExeption', new HttpClientException(500, params)],
+    ['HttpClientException', new HttpClientException(404, params)],
+    ['HttpServerException', new HttpClientException(500, params)],
     ['HttpNotFound', new HttpNotFound(params)],
   ];
 
-  vi.mock('../support', () => {
+  vi.mock('../../src/support', () => {
     return {
       supportsErrorCause: () => false,
     };

--- a/packages/exception/vitest.config.ts
+++ b/packages/exception/vitest.config.ts
@@ -1,7 +1,7 @@
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
-const testFiles = ['./src/**/*.test.{js,ts}'];
+const testFiles = ['./src/**/*.test.{js,ts}', './test/**/*.test.{js,ts}'];
 
 import 'error-cause-polyfill/auto';
 


### PR DESCRIPTION
### Validation errors

In some circumstances you might find useful to append the validation errors to 
`HttpBadRequest`. Here's a quick example:

```typescript
const e400 = new HttpBadRequest({
  errors: [
      {
          message: 'Invalid email',
          path: 'email',
          code: 'invalid_email',
      },
      {
          message: 'Invalid address',
          path: ['addresses', 0, 'line1'],
          code: 'empty_string',
      },
  ]
});
console.log(e400.errors)
```
