### PR TITLE
Add convertJdbcToDsn utility function

### DIFF
--- a/.changeset/nine-seals-dress.md
+++ b/.changeset/nine-seals-dress.md
@@ -1,0 +1,19 @@
+---
+'@httpx/dsn-parser': minor
+---
+
+Add convertJdbcToDsn utility function
+
+Helps to convert [jdbc](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) dsn.
+Useful for prisma using [sqlserver](https://www.prisma.io/docs/concepts/database-connectors/sql-server#connection-details).
+
+```typescript
+import { convertJdbcToDsn } from '@httpx/dsn-parser';
+
+const jdbcDsn =
+    'sqlserver://localhost:1433;database=my-db;authentication=default;user=sa;password=pass03$;encrypt=true;trustServerCertificate=true';
+
+const dsn = convertJdbcToDsn(jdbc);
+
+// -> 'sqlserver://localhost:1433?database=my-db&authentication=default&user=sa&password=pass03$&encrypt=true&trustServerCertificate=true'
+```

--- a/packages/dsn-parser/.size-limit.cjs
+++ b/packages/dsn-parser/.size-limit.cjs
@@ -6,7 +6,7 @@ module.exports = [
   {
     name: 'JS (ESM)',
     path: ['dist/index.mjs'],
-    limit: '1.15KB',
+    limit: '1.30KB',
   },
   {
     name: 'JS (CJS)',

--- a/packages/dsn-parser/README.md
+++ b/packages/dsn-parser/README.md
@@ -229,6 +229,24 @@ if (!parsed.success) {
 | `'EMPTY_DSN'`        | `DSN cannot be empty`   |                 |
 | `'INVALID_PORT'`     | `Invalid port: ${port}` | [1-65535]       |
 
+## Utilities
+
+### convertJdbcToDsn
+
+Utility to convert [jdbc](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) dsn.
+Useful for prisma using [sqlserver](https://www.prisma.io/docs/concepts/database-connectors/sql-server#connection-details).
+
+```typescript
+import { convertJdbcToDsn } from "@httpx/dsn-parser";
+
+const jdbcDsn =
+  "sqlserver://localhost:1433;database=my-db;authentication=default;user=sa;password=pass03$;encrypt=true;trustServerCertificate=true";
+
+const dsn = convertJdbcToDsn(jdbc);
+
+// -> 'sqlserver://localhost:1433?database=my-db&authentication=default&user=sa&password=pass03$&encrypt=true&trustServerCertificate=true'
+```
+
 ## Faq
 
 ### Zod integration example

--- a/packages/dsn-parser/docs/api/README.md
+++ b/packages/dsn-parser/docs/api/README.md
@@ -13,6 +13,7 @@
 ### Functions
 
 - [assertParsableDsn](README.md#assertparsabledsn)
+- [convertJdbcToDsn](README.md#convertjdbctodsn)
 - [isParsableDsn](README.md#isparsabledsn)
 - [parseDsn](README.md#parsedsn)
 - [parseDsnOrThrow](README.md#parsedsnorthrow)
@@ -74,6 +75,22 @@ asserts dsn is string
 **`Throws`**
 
 Error when not parsable
+
+---
+
+### convertJdbcToDsn
+
+▸ **convertJdbcToDsn**(`jdbc`): `string`
+
+#### Parameters
+
+| Name   | Type     |
+| :----- | :------- |
+| `jdbc` | `string` |
+
+#### Returns
+
+`string`
 
 ---
 

--- a/packages/dsn-parser/src/__tests__/convert-jdbc-to-dsn.test.ts
+++ b/packages/dsn-parser/src/__tests__/convert-jdbc-to-dsn.test.ts
@@ -23,4 +23,14 @@ describe('convertJdbcToDsn', () => {
       },
     });
   });
+  it('should return a dsn string from a minimal jdbc dsn', () => {
+    const jdbc = 'sqlserver://localhost:1433';
+    const dsn = convertJdbcToDsn(jdbc);
+    expect(dsn).toStrictEqual('sqlserver://localhost:1433');
+    expect(parseDsnOrThrow(dsn)).toStrictEqual({
+      driver: 'sqlserver',
+      host: 'localhost',
+      port: 1433,
+    });
+  });
 });

--- a/packages/dsn-parser/src/__tests__/convert-jdbc-to-dsn.test.ts
+++ b/packages/dsn-parser/src/__tests__/convert-jdbc-to-dsn.test.ts
@@ -1,0 +1,26 @@
+import { convertJdbcToDsn } from '../convert-jdbc-to-dsn';
+import { parseDsnOrThrow } from '../parse-dsn-or-throw';
+
+describe('convertJdbcToDsn', () => {
+  it('should return a dsn string from a valid jdbc string', () => {
+    const jdbc =
+      'sqlserver://localhost:1433;database=my-db;authentication=default;user=sa;password=pass03$;encrypt=true;trustServerCertificate=true';
+    const dsn = convertJdbcToDsn(jdbc);
+    expect(dsn).toStrictEqual(
+      'sqlserver://localhost:1433?database=my-db&authentication=default&user=sa&password=pass03$&encrypt=true&trustServerCertificate=true'
+    );
+    expect(parseDsnOrThrow(dsn)).toStrictEqual({
+      driver: 'sqlserver',
+      host: 'localhost',
+      port: 1433,
+      params: {
+        authentication: 'default',
+        database: 'my-db',
+        encrypt: true,
+        password: 'pass03$',
+        trustServerCertificate: true,
+        user: 'sa',
+      },
+    });
+  });
+});

--- a/packages/dsn-parser/src/convert-jdbc-to-dsn.ts
+++ b/packages/dsn-parser/src/convert-jdbc-to-dsn.ts
@@ -1,4 +1,6 @@
 export const convertJdbcToDsn = (jdbc: string): string => {
   const [part1, ...rest] = jdbc.split(';');
-  return `${part1}?${(rest ?? []).join('&')}`;
+  return [part1, rest ? rest.join('&') : undefined]
+    .filter((v) => Boolean(v))
+    .join('?');
 };

--- a/packages/dsn-parser/src/convert-jdbc-to-dsn.ts
+++ b/packages/dsn-parser/src/convert-jdbc-to-dsn.ts
@@ -1,0 +1,4 @@
+export const convertJdbcToDsn = (jdbc: string): string => {
+  const [part1, ...rest] = jdbc.split(';');
+  return `${part1}?${(rest ?? []).join('&')}`;
+};

--- a/packages/dsn-parser/src/index.ts
+++ b/packages/dsn-parser/src/index.ts
@@ -7,3 +7,4 @@ export { parseDsn } from './parse-dsn';
 export { parseDsnOrThrow } from './parse-dsn-or-throw';
 export { assertParsableDsn } from './assert-parsable-dsn';
 export { isParsableDsn } from './is-parsable-dsn';
+export { convertJdbcToDsn } from './convert-jdbc-to-dsn';

--- a/packages/json-api/docs/api/README.md
+++ b/packages/json-api/docs/api/README.md
@@ -1,6 +1,6 @@
 @httpx/json-api
 
-# @httpx/json-api - v0.4.0
+# @httpx/json-api - v0.4.1
 
 ## Table of contents
 

--- a/packages/json-api/docs/api/classes/JsonApiErrorFactory.md
+++ b/packages/json-api/docs/api/classes/JsonApiErrorFactory.md
@@ -1,4 +1,4 @@
-[@httpx/json-api - v0.4.0](../README.md) / JsonApiErrorFactory
+[@httpx/json-api - v0.4.1](../README.md) / JsonApiErrorFactory
 
 # Class: JsonApiErrorFactory
 

--- a/packages/json-api/docs/api/classes/JsonApiResponseFactory.md
+++ b/packages/json-api/docs/api/classes/JsonApiResponseFactory.md
@@ -1,4 +1,4 @@
-[@httpx/json-api - v0.4.0](../README.md) / JsonApiResponseFactory
+[@httpx/json-api - v0.4.1](../README.md) / JsonApiResponseFactory
 
 # Class: JsonApiResponseFactory
 


### PR DESCRIPTION
Helps to convert [jdbc](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15) dsn.
Useful for prisma using [sqlserver](https://www.prisma.io/docs/concepts/database-connectors/sql-server#connection-details).

```typescript
import { convertJdbcToDsn } from '@httpx/dsn-parser';

const jdbcDsn =
    'sqlserver://localhost:1433;database=my-db;authentication=default;user=sa;password=pass03$;encrypt=true;trustServerCertificate=true';

const dsn = convertJdbcToDsn(jdbc);

// -> 'sqlserver://localhost:1433?database=my-db&authentication=default&user=sa&password=pass03$&encrypt=true&trustServerCertificate=true'
```