### PR TITLE
feat: add issues support in serializer and createHttpException

### DIFF
--- a/.changeset/eight-weeks-sin.md
+++ b/.changeset/eight-weeks-sin.md
@@ -1,0 +1,27 @@
+---
+'@httpx/exception': minor
+---
+
+Add support for HttpUnprocessableEntity.issues in serializer.
+
+```typescript
+import { fromJson, toJson } from '@httpx/exception/serializer';
+
+const e422 = new HttpUnprocessableEntity({
+    message: 'Validation failed',
+    issues: [
+        {
+            message: 'Invalid address',
+            path: ['addresses', 0, 'line1'],
+            code: 'empty_string',
+        },
+    ],
+});
+
+const json = toJson(e422);
+const js = fromJson(json);
+
+expect((js as HttpUnprocessableEntity).issues).toStrictEqual(e422.issues);
+expect(js).toStrictEqual(e422);
+
+```

--- a/.changeset/strange-cameras-hug.md
+++ b/.changeset/strange-cameras-hug.md
@@ -1,0 +1,18 @@
+---
+'@httpx/exception': patch
+---
+
+Fix createHttpException that wasn't allowing issues on HttpUnprocessableEntity
+
+```typescript
+const e422 = createHttpException(422, {
+    message: 'Validation failed',
+    issues: [
+        {
+            message: 'Invalid address',
+            path: ['addresses', 0, 'line1'],
+            code: 'empty_string',
+        },
+    ],
+});
+```

--- a/packages/exception/.size-limit.cjs
+++ b/packages/exception/.size-limit.cjs
@@ -43,12 +43,11 @@ module.exports = [
     import: "{ createHttpException }",
     limit: "1500B", // Will import all server/client exceptions
   },
-
   {
     name: "ESM ({ toJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ toJson }",
-    limit: "800B",
+    limit: "930B",
   },
   {
     name: "ESM ({ fromJson })",

--- a/packages/exception/.size-limit.cjs
+++ b/packages/exception/.size-limit.cjs
@@ -49,12 +49,11 @@ module.exports = [
     import: "{ createHttpException }",
     limit: "900B", // Will import all server/client exceptions
   },
-
   {
     name: "ESM ({ toJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ toJson }",
-    limit: "805B",
+    limit: "950B",
   },
   {
     name: "ESM ({ fromJson })",

--- a/packages/exception/package.json
+++ b/packages/exception/package.json
@@ -131,6 +131,7 @@
     "ts-jest": "29.1.1",
     "tslib": "2.6.2",
     "tsup": "7.2.0",
+    "tupleson": "0.22.1",
     "typedoc": "0.25.2",
     "typedoc-plugin-markdown": "3.16.0",
     "typescript": "5.2.2",

--- a/packages/exception/src/client/HttpUnprocessableEntity.ts
+++ b/packages/exception/src/client/HttpUnprocessableEntity.ts
@@ -1,5 +1,6 @@
 import { HttpClientException } from '../base';
 import type { HttpExceptionParams } from '../types/HttpExceptionParams';
+import type { HttpExceptionParamsWithIssues } from '../types/HttpExceptionParamsWithIssues';
 import type { HttpValidationIssue } from '../types/HttpValidationIssue';
 import type { ValidationError } from '../types/ValidationError';
 import { getSuperArgs, initProtoAndName } from '../utils';
@@ -32,9 +33,7 @@ export class HttpUnprocessableEntity extends HttpClientException {
       | (HttpExceptionParams & {
           /** @deprecated use issues instead */
           errors?: ValidationError[];
-        } & {
-          issues?: HttpValidationIssue[];
-        })
+        } & HttpExceptionParamsWithIssues)
       | string
   ) {
     const {

--- a/packages/exception/src/client/HttpUnprocessableEntity.ts
+++ b/packages/exception/src/client/HttpUnprocessableEntity.ts
@@ -1,5 +1,6 @@
 import { HttpClientException } from '../base';
 import type { HttpExceptionParams } from '../types/HttpExceptionParams';
+import type { HttpExceptionParamsWithIssues } from '../types/HttpExceptionParamsWithIssues';
 import type { HttpValidationIssue } from '../types/HttpValidationIssue';
 import { getSuper } from '../utils';
 
@@ -21,7 +22,10 @@ import { getSuper } from '../utils';
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
  * @see https://httpstatus.in/422/
  */
-export class HttpUnprocessableEntity extends HttpClientException {
+export class HttpUnprocessableEntity
+  extends HttpClientException
+  implements HttpExceptionParamsWithIssues
+{
   static readonly STATUS = 422;
   public readonly issues: HttpValidationIssue[];
 
@@ -37,9 +41,7 @@ export class HttpUnprocessableEntity extends HttpClientException {
       | (HttpExceptionParams & {
           /** @deprecated use issues instead */
           errors?: HttpValidationIssue[];
-        } & {
-          issues?: HttpValidationIssue[];
-        })
+        } & HttpExceptionParamsWithIssues)
       | string
   ) {
     const name = 'UnprocessableEntity';

--- a/packages/exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
+++ b/packages/exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
@@ -1,5 +1,5 @@
 import { HttpException } from '../../../base';
-import { HttpBadRequest } from '../../../client';
+import { HttpBadRequest, HttpUnprocessableEntity } from '../../../client';
 import { convertToSerializable } from '../convertToSerializable';
 import { createFromSerializable } from '../createFromSerializable';
 
@@ -46,6 +46,30 @@ describe('createFromSerializable', () => {
         );
         expect((converted as HttpException)?.code).toStrictEqual(err.code);
       }
+    );
+  });
+
+  it('deserialize issues of HttpUnprocessableEntity', () => {
+    const e422 = new HttpUnprocessableEntity({
+      message: 'Validation failed',
+      issues: [
+        {
+          message: 'Invalid email',
+          path: 'email',
+          code: 'invalid_email',
+        },
+        {
+          message: 'Invalid address',
+          path: ['addresses', 0, 'line1'],
+          code: 'empty_string',
+        },
+      ],
+    });
+
+    const converted = createFromSerializable(convertToSerializable(e422));
+    expect(converted).toStrictEqual(e422);
+    expect((converted as HttpUnprocessableEntity)?.issues).toStrictEqual(
+      e422.issues
     );
   });
 

--- a/packages/exception/src/serializer/mapper/convertToSerializable.ts
+++ b/packages/exception/src/serializer/mapper/convertToSerializable.ts
@@ -1,7 +1,8 @@
 import type { HttpException } from '../../base';
+import { HttpUnprocessableEntity } from '../../client';
 import { isHttpException } from '../../typeguards';
 import { isNativeError } from '../typeguard';
-import type { NativeError, Serializable } from '../types';
+import type { Serializable, NativeError } from '../types';
 
 /**
  * Convert an Error, NativeError or any HttpException to
@@ -45,6 +46,7 @@ export const convertToSerializable = (
       ...(e.code ? { code: e.code } : {}),
       ...(e.method ? { method: e.method } : {}),
       ...(e.errorId ? { errorId: e.errorId } : {}),
+      ...(e instanceof HttpUnprocessableEntity ? { issues: e.issues } : {}),
     };
   }
   return {

--- a/packages/exception/src/serializer/mapper/createFromSerializable.ts
+++ b/packages/exception/src/serializer/mapper/createFromSerializable.ts
@@ -43,6 +43,7 @@ const createHttpExceptionError = (
     errorId: serializable.errorId,
     code: serializable.code,
     cause: cause ? createFromSerializable(cause) : undefined,
+    ...(serializable.issues ? { issues: serializable.issues } : {}),
   };
   let e: HttpException;
   try {

--- a/packages/exception/src/serializer/types/index.ts
+++ b/packages/exception/src/serializer/types/index.ts
@@ -4,6 +4,7 @@
  * @see https://262.ecma-international.org/12.0/#sec-well-known-intrinsic-objects
  */
 import type { HttpMethod } from '../../types/HttpMethod';
+import type { HttpValidationIssue } from '../../types/HttpValidationIssue';
 
 export type NativeError =
   | Error
@@ -34,6 +35,7 @@ export type HttpExceptionFields = NativeErrorFields & {
   method?: HttpMethod;
   errorId?: string;
   code?: string;
+  issues?: HttpValidationIssue[];
 };
 
 export type Serializable =

--- a/packages/exception/src/types/FromStatusCode.ts
+++ b/packages/exception/src/types/FromStatusCode.ts
@@ -1,0 +1,18 @@
+import type {
+  HttpClientException,
+  HttpException,
+  HttpServerException,
+} from '../base';
+import type { HttpUnprocessableEntity } from '../client';
+import type { HttpExceptionParams } from './HttpExceptionParams';
+import type { HttpExceptionParamsWithIssues } from './HttpExceptionParamsWithIssues';
+
+export type HttpStatusCodesWithIssues = 422;
+
+export type HttpExceptionParamsFromStatus<T> =
+  T extends HttpStatusCodesWithIssues
+    ? HttpExceptionParamsWithIssues
+    : HttpExceptionParams;
+export type HttpExceptionFromStatus<T> = T extends HttpStatusCodesWithIssues
+  ? HttpUnprocessableEntity
+  : HttpClientException | HttpException | HttpServerException;

--- a/packages/exception/src/types/HttpExceptionParamsWithIssues.ts
+++ b/packages/exception/src/types/HttpExceptionParamsWithIssues.ts
@@ -1,0 +1,9 @@
+import type { HttpExceptionParams } from './HttpExceptionParams';
+import type { HttpValidationIssue } from './HttpValidationIssue';
+
+/**
+ * Special case for 422 UnprocessableEntity
+ */
+export type HttpExceptionParamsWithIssues = HttpExceptionParams & {
+  issues?: HttpValidationIssue[];
+};

--- a/packages/exception/test/specs/general-specs.test.ts
+++ b/packages/exception/test/specs/general-specs.test.ts
@@ -1,8 +1,10 @@
 import statuses from 'statuses';
 import { HttpClientException, HttpException } from '../../src/base';
-import { HttpNotFound } from '../../src/client';
+import { HttpNotFound, HttpUnprocessableEntity } from '../../src/client';
 import { createHttpException } from '../../src/factory';
+
 import { statusMap } from '../../src/status';
+import type { HttpExceptionParamsWithIssues } from '../../src/types/HttpExceptionParamsWithIssues';
 
 describe('Common specs', () => {
   describe('compare with npm:statuses package', () => {
@@ -58,6 +60,24 @@ describe('Common specs', () => {
       expect(err).toBeInstanceOf(HttpNotFound);
       expect(err).toBeInstanceOf(HttpException);
       expect(err).toBeInstanceOf(HttpClientException);
+    });
+  });
+
+  describe('createHttpException', () => {
+    it('should support HttpUnprocessableEntity with issues', () => {
+      const e422Params: HttpExceptionParamsWithIssues = {
+        message: 'Validation failed',
+        issues: [
+          {
+            message: 'Invalid address',
+            path: ['addresses', 0, 'line1'],
+            code: 'empty_string',
+          },
+        ],
+      };
+      expect(createHttpException(422, e422Params)).toStrictEqual(
+        new HttpUnprocessableEntity(e422Params)
+      );
     });
   });
 });

--- a/packages/exception/test/specs/json-serializer.test.ts
+++ b/packages/exception/test/specs/json-serializer.test.ts
@@ -1,0 +1,32 @@
+import { HttpUnprocessableEntity } from '../../src';
+import { fromJson, toJson } from '../../src/serializer';
+
+describe('Json serialization', () => {
+  describe('HttpUnprocessableEntity with issues', () => {
+    const e422 = new HttpUnprocessableEntity({
+      message: 'Validation failed',
+      url: 'http://',
+      method: 'POST',
+      errorId: '12',
+      issues: [
+        {
+          message: 'Invalid email',
+          path: 'email',
+          code: 'invalid_email',
+        },
+        {
+          message: 'Invalid address',
+          path: ['addresses', 0, 'line1'],
+          code: 'empty_string',
+        },
+      ],
+    });
+
+    it('should return the same object', () => {
+      const json = toJson(e422);
+      const js = fromJson(json);
+      expect((js as HttpUnprocessableEntity).issues).toStrictEqual(e422.issues);
+      expect(js).toStrictEqual(e422);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1389,6 +1389,7 @@ __metadata:
     ts-jest: "npm:29.1.1"
     tslib: "npm:2.6.2"
     tsup: "npm:7.2.0"
+    tupleson: "npm:0.22.1"
     typedoc: "npm:0.25.2"
     typedoc-plugin-markdown: "npm:3.16.0"
     typescript: "npm:5.2.2"
@@ -12353,6 +12354,13 @@ __metadata:
   bin:
     tty-table: adapters/terminal-adapter.js
   checksum: c194abc673d178bef9dbcaf44c19db5560b7e126ad3fe86ef1c2bddee848a6ad6e8df419375feee4c89f7793c96378db7095963fe5c1b8e015b9e4f1b6c80916
+  languageName: node
+  linkType: hard
+
+"tupleson@npm:0.22.1":
+  version: 0.22.1
+  resolution: "tupleson@npm:0.22.1"
+  checksum: afb87fd4d26937f0a5b0138e34304883612996233755fb73d58edc2286767af27745948b423969fe9bab08d0127d3d6e5f6b7dc522fdce69dff2dfa593e4f2f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add support for HttpUnprocessableEntity.issues in serializer.

```typescript
import { fromJson, toJson } from '@httpx/exception/serializer';

const e422 = new HttpUnprocessableEntity({
    message: 'Validation failed',
    issues: [
        {
            message: 'Invalid address',
            path: ['addresses', 0, 'line1'],
            code: 'empty_string',
        },
    ],
});

const json = toJson(e422);
const js = fromJson(json);

expect((js as HttpUnprocessableEntity).issues).toStrictEqual(e422.issues);
expect(js).toStrictEqual(e422);

```
And Fix createHttpException that wasn't allowing issues on HttpUnprocessableEntity

```typescript
const e422 = createHttpException(422, {
    message: 'Validation failed',
    issues: [
        {
            message: 'Invalid address',
            path: ['addresses', 0, 'line1'],
            code: 'empty_string',
        },
    ],
});
```