### PR TITLE
fix: when throwing a SerializerError with cause on unsupported browsers

### DIFF
--- a/.changeset/clean-pigs-reply.md
+++ b/.changeset/clean-pigs-reply.md
@@ -1,0 +1,5 @@
+---
+"@httpx/exception": patch
+---
+
+Fix cause support in SerializerError on env that doesn't support Error.cause

--- a/packages/exception/.size-limit.cjs
+++ b/packages/exception/.size-limit.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 const fullEsmMaxSize = "1495B";
-const fullCjsMaxSize = "1950B";
+const fullCjsMaxSize = "1970B";
 
 /**
  * Will ensure esm tree-shakeability and total size are within expectations.
@@ -118,6 +118,6 @@ module.exports = [
     path: ["dist/index.cjs"],
     import: "{ isHttpException }",
     webpack: true,
-    limit: '1115B',
+    limit: '1140B',
   }
 ];

--- a/packages/exception/src/serializer/error/SerializerError.ts
+++ b/packages/exception/src/serializer/error/SerializerError.ts
@@ -1,3 +1,4 @@
+import { supportsErrorCause } from '../../support/supportsErrorCause';
 import { initProtoAndName } from '../../utils';
 
 export class SerializerError extends Error {
@@ -8,10 +9,9 @@ export class SerializerError extends Error {
     }
   ) {
     const { cause } = params ?? {};
-    if (cause) {
-      super(message, { cause });
-    } else {
-      super(message);
+    super(message);
+    if (supportsErrorCause() && cause instanceof Error) {
+      this.cause = cause;
     }
     initProtoAndName(this, SerializerError);
   }


### PR DESCRIPTION
If the serializer throws an error with a cause on an unsupported browser and no polyfill are set, it might create a runtime error. (very rare)