### PR TITLE
[exception] v3 - do not serialize stack by default

### DIFF
--- a/.changeset/green-lobsters-smoke.md
+++ b/.changeset/green-lobsters-smoke.md
@@ -1,0 +1,5 @@
+---
+"@httpx/exception": minor
+---
+
+Add `SerializerParams.includeStack` to `toJson` and `fromJson` serialization functions.

--- a/.changeset/healthy-fireants-care.md
+++ b/.changeset/healthy-fireants-care.md
@@ -1,0 +1,22 @@
+---
+"@httpx/exception": major
+---
+
+Stack traces won't be serialized anymore by default as they
+might contain sensitive information in production.  
+
+For development or logging, it's possible to opt-in stack serialization selectively in 
+`convertToSerializable`, `createFromSerializable`, `toJson` and `fromJson` functions thanks
+to the `SerializerParams.includeStack` param.
+
+```typescript
+import { fromJson, toJson } from '@httpx/exception';
+
+const json = toJson(new HttpException(500), {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+
+const e = fromJson(json, {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+```

--- a/.changeset/light-pans-smile.md
+++ b/.changeset/light-pans-smile.md
@@ -1,0 +1,5 @@
+---
+"@httpx/exception": minor
+---
+
+Add `SerializerParams.includeStack` to `convertToSerializable` and `createFromSerializable` serialization functions.

--- a/docs/src/pages/exception/index.mdx
+++ b/docs/src/pages/exception/index.mdx
@@ -44,7 +44,7 @@ import { Tabs, Tab, Callout } from 'nextra/components';
 - 👉&nbsp; Usage by [explicit named imports](#by-named-imports) and/or [status code](#by-status-code).
 - 👉&nbsp; If message not provided, defaults to [http error message](#default-messages)
 - 👉&nbsp; Supports pre-defined [contextual](#error-context) information.
-- 👉&nbsp; Built-in [serializer](https://belgattitude.github.io/httpx/#/?id=serializer) to allow cross-env uses (ssr, rsc, superjson, logs...).
+- 👉&nbsp; Built-in [serializer](#serializer) to allow cross-env uses (ssr, rsc, superjson, logs...).
 - 👉&nbsp; Supports [nested error](#nested-errors) through native [Error.cause](https://belgattitude.github.io/httpx/#/?id=about-errorcause) support.
 - 👉&nbsp; [Extends](#class-diagram) native Error class with [stacktrace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) support.
 - 👉&nbsp; No deps. [Node, edge and modern browsers compatibility](#compatibility),
@@ -372,20 +372,20 @@ const deserialized = fromJson(json);
 
 
 <details>
-  <summary>Example for stack traces serialization.</summary>
+<summary>Example for stack traces serialization.</summary>
 
-  ```typescript
-  import { fromJson, toJson } from "@httpx/exception/serializer";
+```typescript
+import { fromJson, toJson } from "@httpx/exception/serializer";
 
-  // To include stack traces (not safe in production)
-  const jsonWithStack = toJson(new HttpException(500), {
+// To include stack traces (not safe in production)
+const jsonWithStack = toJson(new HttpException(500), {
   includeStack: process.env.NODE_ENV === 'development',
 });
 
-  const eWithStrack = fromJson(json, {
+const eWithStrack = fromJson(json, {
   includeStack: process.env.NODE_ENV === 'development',
 });
-  ```
+```
 </details>
 
 ### Serializable
@@ -408,22 +408,21 @@ const deserialized = createFromSerializable(serializableObject);
 ```
 
 <details>
-  <summary>Example for stack traces serialization.</summary>
+<summary>Example for stack traces serialization.</summary>
 
-  ```typescript
-  import {
+```typescript
+import {
   convertToSerializable,
   createFromSerializable,
 } from "@httpx/exception/serializer";
 
-
-  const serializableObject = convertToSerializable(e, {
+const serializableObject = convertToSerializable(e, {
   includeStack: process.env.NODE_ENV === 'development',
 });
-  const deserialized = createFromSerializable(serializableObject, {
+const deserialized = createFromSerializable(serializableObject, {
   includeStack: process.env.NODE_ENV === 'development',
 });
-  ```
+```
 </details>
 
 ## Default messages

--- a/docs/src/pages/exception/index.mdx
+++ b/docs/src/pages/exception/index.mdx
@@ -484,22 +484,23 @@ const alternate = new HttpServerException({
 ### Bundle size
 
 Code and bundler have been tuned to target a minimal compressed footprint
-for the browser. In typical usage the bundle size will vary between 400b to 660b compressed
+for the browser. In ESM, typical usage the bundle size will vary between 400b to 660b compressed
 (including default messages for the 43 status codes).
 
 ESM individual imports are tracked by a
 [size-limit configuration](../.size-limit.cjshttps://github.com/belgattitude/httpx/blob/main/packages/dsn-parser/.size-limit.cjs).
 
-| Scenario                                         | Size (compressed) |
-| ------------------------------------------------ | ----------------: |
-| Import generic exception (`HttpClientException`) |            ~ 370b |
-| Import 1 client exception                        |            ~ 400b |
-| Import 2 client exceptions                       |            ~ 412b |
-| Import 6 client exceptions                       |            ~ 425b |
-| Import 1 client + 1 server exceptions            |            ~ 416b |
-| Import `createHttpException` (all 43 exceptions) |            ~ 660b |
-| Import `fromJson` (incl createHttpException)     |           ~ 1100b |
-| All exceptions + typeguards + serializer         |           ~ 1500b |
+| Scenario                                           | Size (compressed) |
+| -------------------------------------------------- | ----------------: |
+| Import generic exception (`HttpClientException`)   |            ~ 370b |
+| Import 1 client exception                          |            ~ 400b |
+| Import 2 client exceptions                         |            ~ 412b |
+| Import 6 client exceptions                         |            ~ 425b |
+| Import 1 client + 1 server exceptions              |            ~ 416b |
+| Import `createHttpException` (all 43 exceptions)   |            ~ 660b |
+| Import `fromJson` (incl createHttpException)       |           ~ 1140b |
+| All serializer functions + exceptions + typeguards |           ~ 1500b |
+
 
 > For CJS usage (not recommended) track the size on [bundlephobia](https://bundlephobia.com/package/@httpx/exception@latest).
 

--- a/docs/src/pages/exception/index.mdx
+++ b/docs/src/pages/exception/index.mdx
@@ -346,10 +346,18 @@ the runtime.
 Additionally, you can pass any native errors (`Error`, `EvalError`, `RangeError`, `ReferenceError`,
 `SyntaxError`, `TypeError`, `URIError`) as well as a custom one (the later will be transformed to the base type Error).
 
+⚠️ **Since v3.0.0**:
+
+For security reasons [stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack)
+won't be serialized anymore by default as they might contain sensitive information in production. To opt-in selectively
+for stack traces serialization (ie: development or logging)
+`convertToSerializable`, `createFromSerializable`, `toJson` and `fromJson` functions
+accepts a `SerializerParams.includeStack` param as second argument.
+
 ### JSON
 
 ```typescript
-import { fromJson, toJson } from "@httpx/http-exception/serializer";
+import { fromJson, toJson } from "@httpx/exception/serializer";
 
 const e = new HttpForbidden();
 
@@ -359,8 +367,26 @@ const deserialized = fromJson(json);
 // e === deserialized
 ```
 
-> **Note**
+> **Tip**
 > See also how to integrate with [superjson](https://github.com/blitz-js/superjson#recipes)
+
+
+<details>
+  <summary>Example for stack traces serialization.</summary>
+
+  ```typescript
+  import { fromJson, toJson } from "@httpx/exception/serializer";
+
+  // To include stack traces (not safe in production)
+  const jsonWithStack = toJson(new HttpException(500), {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+
+  const eWithStrack = fromJson(json, {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+  ```
+</details>
 
 ### Serializable
 
@@ -370,7 +396,7 @@ Same as JSON but before json.parse/stringify. Allows to use a different encoder.
 import {
   convertToSerializable,
   createFromSerializable,
-} from "@httpx/http-exception/serializer";
+} from "@httpx/exception/serializer";
 
 const e = new HttpForbidden({
   cause: new Error("Token was revoked"),
@@ -380,6 +406,25 @@ const serializableObject = convertToSerializable(e);
 const deserialized = createFromSerializable(serializableObject);
 // e === deserialized
 ```
+
+<details>
+  <summary>Example for stack traces serialization.</summary>
+
+  ```typescript
+  import {
+  convertToSerializable,
+  createFromSerializable,
+} from "@httpx/exception/serializer";
+
+
+  const serializableObject = convertToSerializable(e, {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+  const deserialized = createFromSerializable(serializableObject, {
+  includeStack: process.env.NODE_ENV === 'development',
+});
+  ```
+</details>
 
 ## Default messages
 

--- a/packages/exception/.size-limit.cjs
+++ b/packages/exception/.size-limit.cjs
@@ -83,19 +83,19 @@ module.exports = [
     name: "ESM serializer ({ toJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ toJson }",
-    limit: "855B",
+    limit: "870B",
   },
   {
     name: "ESM serializer ({ fromJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ fromJson }",
-    limit: "1100B",
+    limit: "1120B",
   },
   {
     name: "ESM serializer ({ fromJson, toJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ fromJson, toJson }",
-    limit: "1370B",
+    limit: "1420B",
   },
   {
     name: "ESM experimental ({ tryOrFail })",

--- a/packages/exception/.size-limit.cjs
+++ b/packages/exception/.size-limit.cjs
@@ -89,13 +89,13 @@ module.exports = [
     name: "ESM serializer ({ fromJson })",
     path: ["dist/serializer/index.mjs"],
     import: "{ fromJson }",
-    limit: "1120B",
+    limit: "1150B",
   },
   {
-    name: "ESM serializer ({ fromJson, toJson })",
+    name: "ESM all serializer ({ fromJson, toJson, convertToSerializable, createFromSerializable })",
     path: ["dist/serializer/index.mjs"],
-    import: "{ fromJson, toJson }",
-    limit: "1420B",
+    import: "{ fromJson, toJson, createFromSerializable, convertToSerializable }",
+    limit: "1425B",
   },
   {
     name: "ESM experimental ({ tryOrFail })",

--- a/packages/exception/README.md
+++ b/packages/exception/README.md
@@ -19,7 +19,7 @@ to cover cross-environments challenges (RSC, SSR...).
 - 👉&nbsp; Usage by [explicit named imports](#by-named-imports) and/or [status code](#by-status-code).
 - 👉&nbsp; If message not provided, defaults to [http error message](#default-messages)
 - 👉&nbsp; Supports pre-defined [contextual](#error-context) information.
-- 👉&nbsp; Built-in [serializer](https://belgattitude.github.io/httpx/#/?id=serializer) to allow cross-env uses (ssr, rsc, superjson, logs...).
+- 👉&nbsp; Built-in [serializer](#serializer) to allow cross-env uses (ssr, rsc, superjson, logs...).
 - 👉&nbsp; Supports [nested error](#nested-errors) through native [Error.cause](https://belgattitude.github.io/httpx/#/?id=about-errorcause) support.
 - 👉&nbsp; [Extends](#class-diagram) native Error class with [stacktrace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) support.
 - 👉&nbsp; No deps. [Node, edge and modern browsers compatibility](#compatibility),

--- a/packages/exception/README.md
+++ b/packages/exception/README.md
@@ -368,10 +368,18 @@ the runtime.
 Additionally, you can pass any native errors (`Error`, `EvalError`, `RangeError`, `ReferenceError`,
 `SyntaxError`, `TypeError`, `URIError`) as well as a custom one (the later will be transformed to the base type Error).
 
+⚠️ **Since v3.0.0**:
+
+For security reasons [stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack)
+won't be serialized anymore by default as they might contain sensitive information in production. To opt-in selectively
+for stack traces serialization (ie: development or logging)
+`convertToSerializable`, `createFromSerializable`, `toJson` and `fromJson` functions
+accepts a `SerializerParams.includeStack` param as second argument.
+
 ### JSON
 
 ```typescript
-import { fromJson, toJson } from "@httpx/http-exception/serializer";
+import { fromJson, toJson } from "@httpx/exception/serializer";
 
 const e = new HttpForbidden();
 
@@ -381,8 +389,26 @@ const deserialized = fromJson(json);
 // e === deserialized
 ```
 
-> **Note**
+> **Tip**
 > See also how to integrate with [superjson](https://github.com/blitz-js/superjson#recipes)
+
+<details>
+<summary>Example for stack traces serialization.</summary>
+
+```typescript
+import { fromJson, toJson } from "@httpx/exception/serializer";
+
+// To include stack traces (not safe in production)
+const jsonWithStack = toJson(new HttpException(500), {
+  includeStack: process.env.NODE_ENV === "development",
+});
+
+const eWithStrack = fromJson(json, {
+  includeStack: process.env.NODE_ENV === "development",
+});
+```
+
+</details>
 
 ### Serializable
 
@@ -392,7 +418,7 @@ Same as JSON but before json.parse/stringify. Allows to use a different encoder.
 import {
   convertToSerializable,
   createFromSerializable,
-} from "@httpx/http-exception/serializer";
+} from "@httpx/exception/serializer";
 
 const e = new HttpForbidden({
   cause: new Error("Token was revoked"),
@@ -402,6 +428,25 @@ const serializableObject = convertToSerializable(e);
 const deserialized = createFromSerializable(serializableObject);
 // e === deserialized
 ```
+
+<details>
+<summary>Example for stack traces serialization.</summary>
+
+```typescript
+import {
+  convertToSerializable,
+  createFromSerializable,
+} from "@httpx/exception/serializer";
+
+const serializableObject = convertToSerializable(e, {
+  includeStack: process.env.NODE_ENV === "development",
+});
+const deserialized = createFromSerializable(serializableObject, {
+  includeStack: process.env.NODE_ENV === "development",
+});
+```
+
+</details>
 
 ## Default messages
 

--- a/packages/exception/README.md
+++ b/packages/exception/README.md
@@ -506,22 +506,22 @@ const alternate = new HttpServerException({
 ### Bundle size
 
 Code and bundler have been tuned to target a minimal compressed footprint
-for the browser. In typical usage the bundle size will vary between 400b to 660b compressed
+for the browser. In ESM, typical usage the bundle size will vary between 400b to 660b compressed
 (including default messages for the 43 status codes).
 
 ESM individual imports are tracked by a
 [size-limit configuration](https://github.com/belgattitude/httpx/blob/main/packages/dsn-parser/.size-limit.cjs).
 
-| Scenario                                         | Size (compressed) |
-| ------------------------------------------------ | ----------------: |
-| Import generic exception (`HttpClientException`) |            ~ 370b |
-| Import 1 client exception                        |            ~ 400b |
-| Import 2 client exceptions                       |            ~ 412b |
-| Import 6 client exceptions                       |            ~ 425b |
-| Import 1 client + 1 server exceptions            |            ~ 416b |
-| Import `createHttpException` (all 43 exceptions) |            ~ 660b |
-| Import `fromJson` (incl createHttpException)     |           ~ 1100b |
-| All exceptions + typeguards + serializer         |           ~ 1500b |
+| Scenario                                           | Size (compressed) |
+| -------------------------------------------------- | ----------------: |
+| Import generic exception (`HttpClientException`)   |            ~ 370b |
+| Import 1 client exception                          |            ~ 400b |
+| Import 2 client exceptions                         |            ~ 412b |
+| Import 6 client exceptions                         |            ~ 425b |
+| Import 1 client + 1 server exceptions              |            ~ 416b |
+| Import `createHttpException` (all 43 exceptions)   |            ~ 660b |
+| Import `fromJson` (incl createHttpException)       |           ~ 1140b |
+| All serializer functions + exceptions + typeguards |           ~ 1500b |
 
 > For CJS usage (not recommended) track the size on [bundlephobia](https://bundlephobia.com/package/@httpx/exception@latest).
 

--- a/packages/exception/UPGRADE.md
+++ b/packages/exception/UPGRADE.md
@@ -2,7 +2,7 @@
 
 ### From v2.x to v3.x
 
-The param errors have been deprecated since v2.x, issues should be used in place.
+The param `HttpUnprocesssableEntity.errors` have been deprecated since v2.x, `issues` should be used in place.
 
 - Remove deprecated `errors` param from `HttpBadRequest`, use `issues` in `HttpUnprocessableEntity` instead
 - Remove deprecated `errors` params from `HttpUnprocessableEntity`, use `issues` instead
@@ -11,3 +11,33 @@ The following types have been removed:
 
 - Remove deprecated type `HttpStatusCode`, use `HttpErrorStatusCode` instead.
 - Remove deprecated type `ValidationError`, use `HttpValidationIssue` instead.
+
+#### Serializer
+
+For security reasons [stack traces](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack)
+won't be serialized anymore by default as they might contain sensitive information in production. To opt-in selectively
+for stack traces serialization (ie: development or logging)
+`convertToSerializable`, `createFromSerializable`, `toJson` and `fromJson` functions
+accepts a `SerializerParams.includeStack` param as second argument.
+
+<details>
+<summary>Example to opt-in back for stack traces serialization.</summary>
+
+```typescript
+import { fromJson, toJson } from "@httpx/exception/serializer";
+
+// To include stack traces (not safe in production)
+const jsonWithStack = toJson(new HttpException(500), {
+  includeStack: process.env.NODE_ENV === "development",
+});
+
+const eWithStrack = fromJson(json, {
+  includeStack: process.env.NODE_ENV === "development",
+});
+```
+
+</details>
+
+### From v1.x to v2.x
+
+Minimum node version is 18.x

--- a/packages/exception/src/serializer/json/fromJson.ts
+++ b/packages/exception/src/serializer/json/fromJson.ts
@@ -1,10 +1,11 @@
 import type { HttpException } from '../../base';
 import { SerializerError } from '../error';
 import { createFromSerializable } from '../mapper';
-import type { SerializableError } from '../types';
+import type { SerializableError, SerializerParams } from '../types';
 
 export const fromJson = (
-  json: string
+  json: string,
+  params?: SerializerParams
 ): Error | HttpException | SerializerError => {
   let v: SerializableError;
   try {
@@ -14,5 +15,5 @@ export const fromJson = (
       ...(e instanceof Error ? { cause: e } : {}),
     });
   }
-  return createFromSerializable(v);
+  return createFromSerializable(v, params);
 };

--- a/packages/exception/src/serializer/json/toJson.ts
+++ b/packages/exception/src/serializer/json/toJson.ts
@@ -1,12 +1,13 @@
 import type { HttpException } from '../../base';
 import { SerializerError } from '../error';
 import { convertToSerializable } from '../mapper';
-import type { NativeError } from '../types';
+import type { NativeError, SerializerParams } from '../types';
 
 export const toJson = (
-  exception: Error | HttpException | NativeError
+  exception: Error | HttpException | NativeError,
+  params?: SerializerParams
 ): string => {
-  const serializable = convertToSerializable(exception);
+  const serializable = convertToSerializable(exception, params);
   let v: string;
   try {
     v = JSON.stringify(serializable);

--- a/packages/exception/src/serializer/mapper/__tests__/convertToSerializable.test.ts
+++ b/packages/exception/src/serializer/mapper/__tests__/convertToSerializable.test.ts
@@ -142,4 +142,54 @@ describe('convertToSerializable', () => {
       expect(serializableWithoutCause).toMatchSnapshot();
     });
   });
+
+  describe('when includeStack is set', () => {
+    const eachCases = [
+      [
+        'http-exception-default-include-stack',
+        undefined,
+        false,
+        new HttpException(500),
+      ],
+      [
+        'http-exception-with-include-stack=true',
+        true,
+        true,
+        new HttpException(500),
+      ],
+      [
+        'http-exception-with-include-stack=false',
+        false,
+        false,
+        new HttpException(500),
+      ],
+      [
+        'native-error-default-include-stack',
+        undefined,
+        false,
+        new Error('test'),
+      ],
+      ['native-error-with-include-stack=true', true, true, new Error('test')],
+      [
+        'native-error-with-include-stack=false',
+        false,
+        false,
+        new Error('test'),
+      ],
+    ] as const satisfies [
+      label: string,
+      includeStack: boolean | undefined,
+      hasStack: boolean,
+      error: HttpException | Error,
+    ][];
+
+    it.each(eachCases)(
+      'for "%s" with includeStack="%s", should return stack="%s"',
+      (label, includeStack, hasStack, error) => {
+        const serializable = convertToSerializable(error, { includeStack });
+        const { stack } = serializable;
+        expect(stack === undefined).toBe(!hasStack);
+      }
+    );
+  });
 });

--- a/packages/exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
+++ b/packages/exception/src/serializer/mapper/__tests__/createFromSerializable.test.ts
@@ -119,7 +119,6 @@ describe('createFromSerializable', () => {
       expect(converted).toBeInstanceOf(Error);
       expect(converted.name).toStrictEqual('Error');
       expect(converted.message).toStrictEqual(e.message);
-      expect(converted.stack).toStrictEqual(e.stack);
       expect(converted.cause).toStrictEqual(e.cause);
     });
   });
@@ -133,5 +132,57 @@ describe('createFromSerializable', () => {
         `Can't serialize error at runtime. Received 'object'`
       );
     });
+  });
+
+  describe('when includeStack is set', () => {
+    const eachCases = [
+      [
+        'http-exception-default-include-stack',
+        undefined,
+        false,
+        new HttpException(500),
+      ],
+      [
+        'http-exception-with-include-stack=true',
+        true,
+        true,
+        new HttpException(500),
+      ],
+      [
+        'http-exception-with-include-stack=false',
+        false,
+        false,
+        new HttpException(500),
+      ],
+      [
+        'native-error-default-include-stack',
+        undefined,
+        false,
+        new Error('test'),
+      ],
+      ['native-error-with-include-stack=true', true, true, new Error('test')],
+      [
+        'native-error-with-include-stack=false',
+        false,
+        false,
+        new Error('test'),
+      ],
+    ] as const satisfies [
+      label: string,
+      includeStack: boolean | undefined,
+      hasStack: boolean,
+      error: HttpException | Error,
+    ][];
+
+    it.each(eachCases)(
+      'for "%s" with includeStack="%s", should return stack="%s"',
+      (label, includeStack, hasStack, error) => {
+        const converted = createFromSerializable(convertToSerializable(error), {
+          includeStack,
+        });
+        const { stack } = converted;
+        expect(stack === undefined).toBe(!hasStack);
+      }
+    );
   });
 });

--- a/packages/exception/src/serializer/mapper/convertToSerializable.ts
+++ b/packages/exception/src/serializer/mapper/convertToSerializable.ts
@@ -2,7 +2,7 @@ import type { HttpException } from '../../base';
 import { HttpUnprocessableEntity } from '../../client';
 import { isHttpException } from '../../typeguards';
 import { isNativeError } from '../typeguard';
-import type { NativeError, Serializable } from '../types';
+import type { NativeError, Serializable, SerializerParams } from '../types';
 
 /**
  * Convert an Error, NativeError or any HttpException to
@@ -11,9 +11,11 @@ import type { NativeError, Serializable } from '../types';
  * @link {createFromSerializable}
  */
 export const convertToSerializable = (
-  e: Error | HttpException | NativeError
+  e: Error | HttpException | NativeError,
+  params?: SerializerParams
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ): Serializable => {
+  const { includeStack = false } = params ?? {};
   const {
     cause: c = null,
     message,
@@ -34,7 +36,7 @@ export const convertToSerializable = (
   const common = {
     message,
     name,
-    ...(stack ? { stack } : {}),
+    ...(includeStack && stack ? { stack } : {}),
     ...(cause ? { cause } : {}),
   };
   if (isHttpException(e)) {

--- a/packages/exception/src/serializer/types/index.ts
+++ b/packages/exception/src/serializer/types/index.ts
@@ -21,6 +21,13 @@ type DiscriminateSerializable<T extends Serializable['__type']> = Extract<
   { __type: T }
 >;
 
+export type SerializerParams = {
+  /**
+   * Whether to include stack strack trace in serialized data
+   */
+  includeStack?: boolean;
+};
+
 export type NativeErrorFields = {
   cause?: Serializable;
   /** Error message (a string, non-empty with HttpException subclasses) */


### PR DESCRIPTION
Stack traces won't be serialized anymore by default as they might contain sensitive information in production.  

For development or logging, it's possible to opt-in stack serialization selectively in `convertToSerializable`, `createFromSerializable`, `toJson` and `fromJson` functions thanks to the `SerializerParams.includeStack` param.

```typescript
import { fromJson, toJson } from '@httpx/exception';

const json = toJson(new HttpException(500), {
  includeStack: process.env.NODE_ENV === 'development',
});

const e = fromJson(json, {
  includeStack: process.env.NODE_ENV === 'development',
});
```