### PR TITLE
[@httpx/assert] refactor assertStringNonEmpty

### DIFF
--- a/.changeset/lazy-rice-join.md
+++ b/.changeset/lazy-rice-join.md
@@ -1,0 +1,5 @@
+---
+"@httpx/assert": patch
+---
+
+Fix weak opaque type signature for StringNonEmpty

--- a/.changeset/pretty-rabbits-brush.md
+++ b/.changeset/pretty-rabbits-brush.md
@@ -1,0 +1,5 @@
+---
+"@httpx/assert": minor
+---
+
+Return weak opaque type StringNonEmpty from assertStringNonEmpty

--- a/.changeset/wild-adults-live.md
+++ b/.changeset/wild-adults-live.md
@@ -1,0 +1,5 @@
+---
+"@httpx/assert": minor
+---
+
+BC: rename assertStrNotEmpty to assertStringNonEmpty

--- a/docs/src/pages/assert/index.mdx
+++ b/docs/src/pages/assert/index.mdx
@@ -112,12 +112,12 @@ Alternatively it's possible to provide either a message or function returning
 an Error. For example:
 
 ```typescript
-import { assertEan13 } from '@httpx/assert';
+import { assertEan13, assertStringNonEmpty } from '@httpx/assert';
 import { HttpBadRequest } from '@httpx/exception';
 
 assertEan13('123', 'Not a barcode'); // 👈 Will throw a TypeError('Not a barcode')
 
-assertStrNotEmpty(lang, () => new HttpBadRequest('Missing language'));
+assertStringNonEmpty(lang, () => new HttpBadRequest('Missing language'));
 ```
 
 ## Usage
@@ -180,10 +180,10 @@ assertNumberSafeInt(Number.MAX_SAFE_INTEGER + 1); // 👉 throws
 #### ArrayNonEmpty
 
 
-| Name                | Type      | Opaque type     | Comment         |
-|---------------------|-----------|-----------------|-----------------|
-| isArrayNonEmpty     | `string`  | `ArrayNonEmpty` |  |
-| assertArrayNonEmpty | `string`  | `ArrayNonEmpty` |  |
+| Name                | Type        | Opaque type     | Comment         |
+|---------------------|-------------|-----------------|-----------------|
+| isArrayNonEmpty     | `unknown[]` | `ArrayNonEmpty` |  |
+| assertArrayNonEmpty | `unknown[]` | `ArrayNonEmpty` |  |
 
 
 ```typescript
@@ -192,12 +192,12 @@ import { isArrayNonEmpty, assertArrayNonEmpty, type ArrayNonEmpty } from '@httpx
 isArrayNonEmpty([]) // 👉 false
 isArrayNonEmpty([0,1]) // 👉 true
 isArrayNonEmpty([null]) // 👉 true
-assertArrayNotEmpty([]) // 👉 throws
+assertArrayNonEmpty([]) // 👉 throws
 ```
 
 ### String related
 
-#### StringNotEmpty
+#### StringNonEmpty
 
 | Name                 | Type      | Opaque type      | Comment         |
 |----------------------|-----------|------------------|-----------------|
@@ -300,9 +300,7 @@ isEan13('1234567890128'); // 👈 will check digit too
 assertEan13('1234567890128');
 ```
 
-## About bundle
-
-### Bundle size
+## Bundle size
 
 Code and bundler have been tuned to target a minimal compressed footprint
 for the browser.
@@ -318,9 +316,6 @@ ESM individual imports are tracked by a
 | All typeguards, assertions and helpers |            ~ 900b |
 
 > For CJS usage (not recommended) track the size on [bundlephobia](https://bundlephobia.com/package/@httpx/assert@latest).
-
-
-### Compatibility
 
 ## Compatibility
 
@@ -341,42 +336,3 @@ Special thanks for inspiration:
 
 - [sindresorhus/is](https://github.com/sindresorhus/is)
 - [webmozarts/assert](https://github.com/webmozarts/assert)
-
-## Contributors
-
-Contributions are warmly appreciated. Have a look to the [CONTRIBUTING](https://github.com/belgattitude/httpx/blob/main/CONTRIBUTING.md) document.
-
-## Sponsors
-
-If my OSS work brightens your day, let's take it to new heights together!
-[Sponsor](<[sponsorship](https://github.com/sponsors/belgattitude)>), [coffee](<(https://ko-fi.com/belgattitude)>),
-or star – any gesture of support fuels my passion to improve. Thanks for being awesome! 🙏❤️
-
-### Special thanks to
-
-<table>
-  <tr>
-    <td>
-      <a href="https://www.jetbrains.com/?ref=belgattitude" target="_blank">
-        <img width="65" src="https://asset.brandfetch.io/idarKiKkI-/id53SttZhi.jpeg" alt="Jetbrains logo" />
-      </a>
-    </td>
-    <td>
-      <a href="https://www.embie.be/?ref=belgattitude" target="_blank">
-        <img width="65" src="https://avatars.githubusercontent.com/u/98402122?s=200&v=4" alt="Jetbrains logo" />
-      </a>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <a href="https://www.jetbrains.com/?ref=belgattitude" target="_blank">JetBrains</a>
-    </td>
-    <td align="center">
-      <a href="https://www.embie.be/?ref=belgattitude" target="_blank">Embie.be</a>
-    </td>
-  </tr>
-</table>
-
-## License
-
-MIT © [belgattitude](https://github.com/belgattitude) and contributors.

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -12,6 +12,8 @@ Assertions and typeguards as primitives
 [![downloads](https://img.shields.io/npm/dm/@httpx/assert?style=for-the-badge&labelColor=444)](https://www.npmjs.com/package/@httpx/assert)
 [![license](https://img.shields.io/npm/l/@httpx/assert?style=for-the-badge&labelColor=444)](https://github.com/belgattitude/httpx/blob/main/LICENSE)
 
+> **warning**: pre-v1, use at your own risks
+
 ## Install
 
 ```bash
@@ -183,10 +185,10 @@ assertNumberSafeInt(Number.MAX_SAFE_INTEGER + 1); // 👉 throws
 #### ArrayNonEmpty
 
 
-| Name                | Type      | Opaque type     | Comment         |
-|---------------------|-----------|-----------------|-----------------|
-| isArrayNonEmpty     | `string`  | `ArrayNonEmpty` |  |
-| assertArrayNonEmpty | `string`  | `ArrayNonEmpty` |  |
+| Name                | Type        | Opaque type     | Comment         |
+|---------------------|-------------|-----------------|-----------------|
+| isArrayNonEmpty     | `unknown[]` | `ArrayNonEmpty` |  |
+| assertArrayNonEmpty | `unknown[]` | `ArrayNonEmpty` |  |
 
 
 ```typescript

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -115,12 +115,12 @@ Alternatively it's possible to provide either a message or function returning
 an Error. For example:
 
 ```typescript
-import { assertEan13 } from '@httpx/assert';
+import { assertEan13, assertStringNonEmpty } from '@httpx/assert';
 import { HttpBadRequest } from '@httpx/exception';
 
 assertEan13('123', 'Not a barcode'); // 👈 Will throw a TypeError('Not a barcode')
 
-assertStrNotEmpty(lang, () => new HttpBadRequest('Missing language'));
+assertStringNonEmpty(lang, () => new HttpBadRequest('Missing language'));
 ```
 
 ## Usage
@@ -195,12 +195,12 @@ import { isArrayNonEmpty, assertArrayNonEmpty, type ArrayNonEmpty } from '@httpx
 isArrayNonEmpty([]) // 👉 false
 isArrayNonEmpty([0,1]) // 👉 true
 isArrayNonEmpty([null]) // 👉 true
-assertArrayNotEmpty([]) // 👉 throws
+assertArrayNonEmpty([]) // 👉 throws
 ```
 
 ### String related
 
-#### StringNotEmpty
+#### StringNonEmpty
 
 | Name                 | Type      | Opaque type      | Comment         |
 |----------------------|-----------|------------------|-----------------|

--- a/packages/assert/src/__tests__/string.assert.test.ts
+++ b/packages/assert/src/__tests__/string.assert.test.ts
@@ -1,7 +1,7 @@
 import {
   assertParsableSafeInt,
   assertParsableStrictIsoDateZ,
-  assertStrNotEmpty,
+  assertStringNonEmpty,
 } from '../string.asserts';
 
 describe('string assertions tests', () => {
@@ -46,16 +46,16 @@ describe('string assertions tests', () => {
   });
   describe('assertStrNotEmpty', () => {
     it('should not throw when value is valid', () => {
-      expect(() => assertStrNotEmpty('sdf')).not.toThrow();
+      expect(() => assertStringNonEmpty('sdf')).not.toThrow();
     });
     it('should throw when value is invalid', () => {
-      expect(() => assertStrNotEmpty(new Date())).toThrow(
+      expect(() => assertStringNonEmpty(new Date())).toThrow(
         new TypeError('Value is expected to be a non-empty string, got: Date')
       );
     });
     it('should throw custom error when value is invalid', () => {
       const e = new Error('cool');
-      expect(() => assertStrNotEmpty('', () => e)).toThrow(e);
+      expect(() => assertStringNonEmpty('', () => e)).toThrow(e);
     });
   });
 });

--- a/packages/assert/src/string.asserts.ts
+++ b/packages/assert/src/string.asserts.ts
@@ -1,6 +1,10 @@
 import { formatErrMsg } from './messages/errorMessages';
 import { isParsableSafeInt, isStringNonEmpty } from './string.guards';
-import type { ParsableSafeInt, ParsableStrictIsoDateZ } from './string.types';
+import type {
+  ParsableSafeInt,
+  ParsableStrictIsoDateZ,
+  StringNonEmpty,
+} from './string.types';
 import { isoDateTimeZRegexp } from './string.utils';
 import type { MsgOrErrorFactory } from './types/internal.types';
 import { createAssertException } from './utils/createAssertException';
@@ -12,7 +16,7 @@ import { createAssertException } from './utils/createAssertException';
 export function assertStringNonEmpty(
   v: unknown,
   msgOrErrorFactory?: MsgOrErrorFactory
-): asserts v is string {
+): asserts v is StringNonEmpty {
   if (!isStringNonEmpty(v)) {
     throw createAssertException(
       msgOrErrorFactory,

--- a/packages/assert/src/string.asserts.ts
+++ b/packages/assert/src/string.asserts.ts
@@ -9,7 +9,7 @@ import { createAssertException } from './utils/createAssertException';
  * Assert string is not empty (trims the string by default)
  * @throws TypeError
  */
-export function assertStrNotEmpty(
+export function assertStringNonEmpty(
   v: unknown,
   msgOrErrorFactory?: MsgOrErrorFactory
 ): asserts v is string {

--- a/packages/assert/src/string.types.ts
+++ b/packages/assert/src/string.types.ts
@@ -1,7 +1,6 @@
 import type { WeakOpaqueContainer } from './types/opaque.types';
 
-export type StringNonEmpty = string &
-  WeakOpaqueContainer<'ParsableStrictIsoDateZ'>;
+export type StringNonEmpty = string & WeakOpaqueContainer<'StringNonEmpty'>;
 export type ParsableSafeInt = string & WeakOpaqueContainer<'ParsableSafeInt'>;
 export type ParsableStrictIsoDateZ = string &
   WeakOpaqueContainer<'ParsableStrictIsoDateZ'>;


### PR DESCRIPTION
- Fix weak opaque type signature for StringNonEmpty
- Return weak opaque type StringNonEmpty from assertStringNonEmpty
- BC: rename assertStrNotEmpty to assertStringNonEmpty
