### PR TITLE
[lru] fix getOrSet return type inference

### DIFF
--- a/.changeset/rotten-planes-make.md
+++ b/.changeset/rotten-planes-make.md
@@ -1,0 +1,5 @@
+---
+"@httpx/lru": patch
+---
+
+Fix return type inference for lru.getOrSet()

--- a/packages/lru/.size-limit.ts
+++ b/packages/lru/.size-limit.ts
@@ -17,6 +17,6 @@ module.exports = [
     name: 'require { LruCache } (CJS)',
     import: '{ LruCache }',
     path: ['dist/index.cjs'],
-    limit: '680B',
+    limit: '650B',
   },
 ] satisfies SizeLimitConfig;

--- a/packages/lru/docs/api/README.md
+++ b/packages/lru/docs/api/README.md
@@ -1,8 +1,8 @@
-**@httpx/lru v0.10.1**
+**@httpx/lru v0.11.0**
 
 ***
 
-# @httpx/lru v0.10.1
+# @httpx/lru v0.11.0
 
 ## Classes
 

--- a/packages/lru/docs/api/classes/LruCache.md
+++ b/packages/lru/docs/api/classes/LruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -211,7 +211,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**(`key`, `valueOrFn`): `TValue`
+> **getOrSet**\<`T`\>(`key`, `valueOrFn`): `T`
 
 Get an item from the cache, if the item doesn't exist it will
 create a new entry with the provided value and returns it.
@@ -219,6 +219,12 @@ create a new entry with the provided value and returns it.
 In case of a new entry:
  - it will be marked as most recently used.
  - an eviction will be triggered if the maximum capacity is reached
+
+#### Type Parameters
+
+##### T
+
+`T` *extends* [`SupportedCacheValues`](../type-aliases/SupportedCacheValues.md)
 
 #### Parameters
 
@@ -228,11 +234,11 @@ In case of a new entry:
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -247,7 +253,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 #### Implementation of

--- a/packages/lru/docs/api/classes/NullLruCache.md
+++ b/packages/lru/docs/api/classes/NullLruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -184,7 +184,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**(`_key`, `valueOrFn`): `TValue`
+> **getOrSet**\<`T`\>(`key`, `valueOrFn`): `T`
 
 Get an item from the cache, if the item doesn't exist it will
 create a new entry with the provided value and returns it.
@@ -193,19 +193,25 @@ In case of a new entry:
  - it will be marked as most recently used.
  - an eviction will be triggered if the maximum capacity is reached
 
+#### Type Parameters
+
+##### T
+
+`T` *extends* [`SupportedCacheValues`](../type-aliases/SupportedCacheValues.md)
+
 #### Parameters
 
-##### \_key
+##### key
 
 `TKey`
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -220,7 +226,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 #### Implementation of

--- a/packages/lru/docs/api/classes/NullTimeLruCache.md
+++ b/packages/lru/docs/api/classes/NullTimeLruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -175,7 +175,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**(`_key`, `valueOrFn`, `_ttl?`): `TValue`
+> **getOrSet**\<`T`\>(`_key`, `valueOrFn`, `_ttl?`): `T`
 
 Get an item from the cache, if the item doesn't exist or has expired
 it will create a new entry with the provided value and returns it.
@@ -185,6 +185,12 @@ In case of a new entry:
  - an eviction will be triggered if the maximum capacity is reached
    or the item has expired.
 
+#### Type Parameters
+
+##### T
+
+`T` = `TValue`
+
 #### Parameters
 
 ##### \_key
@@ -193,7 +199,7 @@ In case of a new entry:
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 ##### \_ttl?
 
@@ -201,7 +207,7 @@ In case of a new entry:
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -216,7 +222,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 #### Implementation of

--- a/packages/lru/docs/api/classes/TimeLruCache.md
+++ b/packages/lru/docs/api/classes/TimeLruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -222,7 +222,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**(`key`, `valueOrFn`, `ttl?`): `TValue`
+> **getOrSet**\<`T`\>(`key`, `valueOrFn`, `ttl?`): `T`
 
 Get an item from the cache, if the item doesn't exist or has expired
 it will create a new entry with the provided value and returns it.
@@ -232,6 +232,12 @@ In case of a new entry:
  - an eviction will be triggered if the maximum capacity is reached
    or the item has expired.
 
+#### Type Parameters
+
+##### T
+
+`T` *extends* [`SupportedCacheValues`](../type-aliases/SupportedCacheValues.md)
+
 #### Parameters
 
 ##### key
@@ -240,7 +246,7 @@ In case of a new entry:
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 ##### ttl?
 
@@ -248,7 +254,7 @@ In case of a new entry:
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -263,7 +269,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 #### Implementation of

--- a/packages/lru/docs/api/interfaces/ILruCache.md
+++ b/packages/lru/docs/api/interfaces/ILruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -114,7 +114,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**: (`key`, `valueOrFn`) => `TValue`
+> **getOrSet**: \<`T`\>(`key`, `valueOrFn`) => `T`
 
 Get an item from the cache, if the item doesn't exist it will
 create a new entry with the provided value and returns it.
@@ -122,6 +122,12 @@ create a new entry with the provided value and returns it.
 In case of a new entry:
  - it will be marked as most recently used.
  - an eviction will be triggered if the maximum capacity is reached
+
+#### Type Parameters
+
+##### T
+
+`T` *extends* [`SupportedCacheValues`](../type-aliases/SupportedCacheValues.md)
 
 #### Parameters
 
@@ -131,11 +137,11 @@ In case of a new entry:
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -150,7 +156,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 ***

--- a/packages/lru/docs/api/interfaces/ITimeLruCache.md
+++ b/packages/lru/docs/api/interfaces/ITimeLruCache.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 
@@ -117,7 +117,7 @@ lru.get('key1');   // 👈 undefined
 
 ### getOrSet()
 
-> **getOrSet**: (`key`, `valueOrFn`, `ttl?`) => `TValue`
+> **getOrSet**: \<`T`\>(`key`, `valueOrFn`, `ttl?`) => `T`
 
 Get an item from the cache, if the item doesn't exist or has expired
 it will create a new entry with the provided value and returns it.
@@ -127,6 +127,12 @@ In case of a new entry:
  - an eviction will be triggered if the maximum capacity is reached
    or the item has expired.
 
+#### Type Parameters
+
+##### T
+
+`T` *extends* [`SupportedCacheValues`](../type-aliases/SupportedCacheValues.md)
+
 #### Parameters
 
 ##### key
@@ -135,7 +141,7 @@ In case of a new entry:
 
 ##### valueOrFn
 
-`TValue` | () => `TValue`
+`T` | () => `T`
 
 ##### ttl?
 
@@ -143,7 +149,7 @@ In case of a new entry:
 
 #### Returns
 
-`TValue`
+`T`
 
 #### Example
 
@@ -158,7 +164,7 @@ lru.get('key1');                       // 👈 'value1'
 // Will trigger an eviction as capacity (2) is reached.
 lru.getOrSet('key3', () => 'value3');
 
-lru.get('key1');                       // 👈 undefined (first entry was evicted)
+lru.get('key1'); // 👈 undefined (first entry was evicted)
 ```
 
 #### Overrides

--- a/packages/lru/docs/api/interfaces/LruCacheHasOptions.md
+++ b/packages/lru/docs/api/interfaces/LruCacheHasOptions.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 

--- a/packages/lru/docs/api/type-aliases/BaseCacheKeyTypes.md
+++ b/packages/lru/docs/api/type-aliases/BaseCacheKeyTypes.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 

--- a/packages/lru/docs/api/type-aliases/LruCacheParams.md
+++ b/packages/lru/docs/api/type-aliases/LruCacheParams.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 

--- a/packages/lru/docs/api/type-aliases/SupportedCacheValues.md
+++ b/packages/lru/docs/api/type-aliases/SupportedCacheValues.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 

--- a/packages/lru/docs/api/type-aliases/TimeLruCacheParams.md
+++ b/packages/lru/docs/api/type-aliases/TimeLruCacheParams.md
@@ -1,4 +1,4 @@
-[**@httpx/lru v0.10.1**](../README.md)
+[**@httpx/lru v0.11.0**](../README.md)
 
 ***
 

--- a/packages/lru/src/__tests__/all-lru-common-operations.test.ts
+++ b/packages/lru/src/__tests__/all-lru-common-operations.test.ts
@@ -1,3 +1,5 @@
+import { expectTypeOf } from 'vitest';
+
 import { LruCache, type LruCacheParams } from '../lru-cache';
 import { TimeLruCache } from '../time-lru-cache';
 
@@ -141,6 +143,27 @@ describe.each(lruCaches)('Common operations', (cacheType, createCache) => {
       expect(value2).toBe('value2');
       expect(value3).toBe('value3');
       expect(lru.size).toBe(3);
+    });
+    it('should automatically infer the type', () => {
+      const lru = createCache({ maxSize: 1 });
+      const str = 'string_not_inferred_as_const' as string;
+      const fromValue = lru.getOrSet('key', str);
+      expectTypeOf(fromValue).toEqualTypeOf<string>();
+      const fromValueFn = lru.getOrSet('key', () => str);
+      expectTypeOf(fromValueFn).toEqualTypeOf<string>();
+    });
+    it('should allow to type with a generic', () => {
+      const lru = createCache({ maxSize: 1 });
+      const withTypedString = lru.getOrSet<string>('test', 'string');
+      expectTypeOf(withTypedString).toEqualTypeOf<string>();
+      const withTypedFnString = lru.getOrSet<string>('test', () => 'string');
+      expectTypeOf(withTypedFnString).toEqualTypeOf<string>();
+    });
+    // eslint-disable-next-line @vitest/expect-expect
+    it('should not allow to type with a unsupported type', () => {
+      const lru = createCache({ maxSize: 1 });
+      // @ts-expect-error - Unsupported type
+      lru.getOrSet('key', new Promise(() => {}));
     });
   });
   describe(`${cacheType}.[Symbol.iterator]`, () => {

--- a/packages/lru/src/__tests__/types.test.ts
+++ b/packages/lru/src/__tests__/types.test.ts
@@ -4,15 +4,16 @@ import type { SupportedCacheValues } from '../types';
 
 describe('Types tests', () => {
   describe('SupportedCacheValues', () => {
-    it('should pass', () => {
-      const _str: SupportedCacheValues = 'string';
-      expectTypeOf(_str).toEqualTypeOf<string>();
-
+    it('should allow supported types', () => {
+      const _string: SupportedCacheValues = 'string';
+      const _number: SupportedCacheValues = 1;
+      expectTypeOf(_string).toEqualTypeOf<string>();
+      expectTypeOf(_number).toEqualTypeOf<number>();
+    });
+    // eslint-disable-next-line @vitest/expect-expect
+    it('should not allow unsupported types', () => {
       // @ts-expect-error - should not allow undefined
       const _undefined: SupportedCacheValues = undefined;
-
-      const _object: SupportedCacheValues = new Intl.Locale('en');
-
       // @ts-expect-error - should not allow promises
       const _async: SupportedCacheValues = new Promise(() => {});
     });

--- a/packages/lru/src/lru-cache.interface.ts
+++ b/packages/lru/src/lru-cache.interface.ts
@@ -116,10 +116,10 @@ export interface ILruCache<
    * // Will trigger an eviction as capacity (2) is reached.
    * lru.getOrSet('key3', () => 'value3');
    *
-   * lru.get('key1');                       // 👈 undefined (first entry was evicted)
+   * lru.get('key1'); // 👈 undefined (first entry was evicted)
    * ```
    */
-  getOrSet: (key: TKey, valueOrFn: TValue | (() => TValue)) => TValue;
+  getOrSet: <T extends TValue>(key: TKey, valueOrFn: T | (() => T)) => T;
 
   /**
    * Get an item without marking it as recently used or undefined if item doesn't exist.

--- a/packages/lru/src/lru-cache.ts
+++ b/packages/lru/src/lru-cache.ts
@@ -134,13 +134,15 @@ export class LruCache<
     return data.value;
   }
 
-  getOrSet(key: TKey, valueOrFn: TValue | (() => TValue)): TValue {
-    if (this.#cache.has(key)) {
-      return this.get(key)!;
+  getOrSet<T extends TValue>(key: TKey, valueOrFn: T | (() => T)): T {
+    const val = this.get(key);
+    if (val === undefined) {
+      const value =
+        typeof valueOrFn === 'function' ? (valueOrFn as () => T)() : valueOrFn;
+      this.set(key, value as unknown as TValue);
+      return value;
     }
-    const value = typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn;
-    this.set(key, value);
-    return value;
+    return val as unknown as T;
   }
 
   peek(key: TKey): TValue | undefined {

--- a/packages/lru/src/null-lru-cache.ts
+++ b/packages/lru/src/null-lru-cache.ts
@@ -45,8 +45,10 @@ export class NullLruCache<
     return undefined;
   }
 
-  getOrSet(_key: TKey, valueOrFn: TValue | (() => TValue)): TValue {
-    return typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn;
+  getOrSet<T extends TValue>(key: TKey, valueOrFn: T | (() => T)): T {
+    return typeof valueOrFn === 'function'
+      ? (valueOrFn as () => T)()
+      : valueOrFn;
   }
 
   peek(_key: TKey): undefined {

--- a/packages/lru/src/null-time-lru-cache.ts
+++ b/packages/lru/src/null-time-lru-cache.ts
@@ -47,12 +47,14 @@ export class NullTimeLruCache<
     return undefined;
   }
 
-  getOrSet(
+  getOrSet<T = TValue>(
     _key: TKey,
-    valueOrFn: TValue | (() => TValue),
+    valueOrFn: T | (() => T),
     _ttl?: Milliseconds
-  ): TValue {
-    return typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn;
+  ): T {
+    return typeof valueOrFn === 'function'
+      ? (valueOrFn as () => T)()
+      : valueOrFn;
   }
 
   peek(_key: TKey): undefined {

--- a/packages/lru/src/time-lru-cache.interface.ts
+++ b/packages/lru/src/time-lru-cache.interface.ts
@@ -135,14 +135,14 @@ export interface ITimeLruCache<
    * // Will trigger an eviction as capacity (2) is reached.
    * lru.getOrSet('key3', () => 'value3');
    *
-   * lru.get('key1');                       // 👈 undefined (first entry was evicted)
+   * lru.get('key1'); // 👈 undefined (first entry was evicted)
    * ```
    */
-  getOrSet: (
+  getOrSet: <T extends TValue>(
     key: TKey,
-    valueOrFn: TValue | (() => TValue),
+    valueOrFn: T | (() => T),
     ttl?: Milliseconds
-  ) => TValue;
+  ) => T;
 
   /**
    * Get an item without marking it as recently used. Will return undefined if

--- a/packages/lru/src/time-lru-cache.ts
+++ b/packages/lru/src/time-lru-cache.ts
@@ -167,18 +167,19 @@ export class TimeLruCache<
     return data.value;
   }
 
-  getOrSet(
+  getOrSet<T extends TValue>(
     key: TKey,
-    valueOrFn: TValue | (() => TValue),
+    valueOrFn: T | (() => T),
     ttl?: Milliseconds
-  ): TValue {
+  ): T {
     const val = this.get(key);
     if (val === undefined) {
-      const value = typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn;
-      this.set(key, value, ttl);
+      const value =
+        typeof valueOrFn === 'function' ? (valueOrFn as () => T)() : valueOrFn;
+      this.set(key, value as unknown as TValue, ttl);
       return value;
     }
-    return val;
+    return val as unknown as T;
   }
 
   peek(key: TKey): TValue | undefined {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type inference and type safety for the `getOrSet` method, allowing more precise return types when interacting with the cache.

* **Documentation**
  * Updated documentation to reflect new generic method signatures and improved type parameter descriptions.
  * Bumped documentation version references from v0.10.1 to v0.11.0.

* **Tests**
  * Added and enhanced tests to verify correct type inference and enforcement for the `getOrSet` method, including checks for supported and unsupported types.

* **Chores**
  * Reduced the package size limit for the CommonJS build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->